### PR TITLE
Add authentication login and registration routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+.next
+out
+build
+
+# env
+.env

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "../../../../lib/prisma";
+import bcrypt from "bcryptjs";
+import jwt from "jsonwebtoken";
+
+export async function POST(req: NextRequest) {
+  try {
+    const { email, password } = await req.json();
+    if (!email || !password) {
+      return NextResponse.json({ error: "email and password required" }, { status: 400 });
+    }
+
+    const user = await prisma.user.findUnique({ where: { email } });
+    if (!user) {
+      return NextResponse.json({ error: "invalid credentials" }, { status: 401 });
+    }
+
+    const valid = await bcrypt.compare(password, user.password);
+    if (!valid) {
+      return NextResponse.json({ error: "invalid credentials" }, { status: 401 });
+    }
+
+    const secret = process.env.JWT_SECRET;
+    if (!secret) {
+      return NextResponse.json({ error: "jwt secret not configured" }, { status: 500 });
+    }
+
+    const token = jwt.sign({ id: user.id, email: user.email }, secret, { expiresIn: "1h" });
+    const res = NextResponse.json({ message: "login successful" });
+    res.cookies.set("token", token, {
+      httpOnly: true,
+      path: "/",
+      sameSite: "lax",
+      secure: process.env.NODE_ENV === "production",
+    });
+    return res;
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message }, { status: 500 });
+  }
+}

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "../../../../lib/prisma";
+import bcrypt from "bcryptjs";
+
+export async function POST(req: NextRequest) {
+  try {
+    const { email, password } = await req.json();
+    if (!email || !password) {
+      return NextResponse.json({ error: "email and password required" }, { status: 400 });
+    }
+
+    const existing = await prisma.user.findUnique({ where: { email } });
+    if (existing) {
+      return NextResponse.json({ error: "user already exists" }, { status: 409 });
+    }
+
+    const hashed = await bcrypt.hash(password, 10);
+    const user = await prisma.user.create({ data: { email, password: hashed } });
+
+    return NextResponse.json({ id: user.id, email: user.email }, { status: 201 });
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message }, { status: 500 });
+  }
+}


### PR DESCRIPTION
 Summary
- implement POST /api/auth/login to verify user credentials and return JWT via HttpOnly cookie
- implement POST /api/auth/register to create new user with hashed password
- add basic .gitignore



